### PR TITLE
feat: add custom rotary slider

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,47 @@
+cmake_minimum_required(VERSION 3.15)
+project(LPHPFilter VERSION 0.0.1)
+
+set(CMAKE_CXX_STANDARD 17)
+
+include(FetchContent)
+FetchContent_Declare(juce
+  GIT_REPOSITORY https://github.com/juce-framework/JUCE.git
+  GIT_TAG 7.0.11
+)
+FetchContent_MakeAvailable(juce)
+
+juce_add_plugin(LPHPFilter
+  COMPANY_NAME "LPHP"
+  IS_SYNTH FALSE
+  NEEDS_MIDI_INPUT FALSE
+  NEEDS_MIDI_OUTPUT FALSE
+  IS_MIDI_EFFECT FALSE
+  EDITOR_WANTS_KEYBOARD_FOCUS FALSE
+  COPY_PLUGIN_AFTER_BUILD TRUE
+  PLUGIN_MANUFACTURER_CODE Juce
+  PLUGIN_CODE Lpf1
+  FORMATS VST3
+  PRODUCT_NAME "LPHPFilter"
+)
+
+juce_generate_juce_header(LPHPFilter)
+
+target_sources(LPHPFilter PRIVATE
+  Source/PluginProcessor.cpp
+  Source/PluginEditor.cpp
+  Source/LowpassHighpassFilter.cpp
+)
+
+target_compile_definitions(LPHPFilter PUBLIC
+  JUCE_WEB_BROWSER=0
+  JUCE_USE_CURL=0
+  JUCE_VST3_CAN_REPLACE_VST2=0
+)
+
+target_link_libraries(LPHPFilter PRIVATE
+  juce::juce_audio_utils
+  juce::juce_dsp
+  juce::juce_recommended_config_flags
+  juce::juce_recommended_lto_flags
+  juce::juce_recommended_warning_flags
+)

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -43,7 +43,7 @@ LPHPFilterAudioProcessorEditor::LPHPFilterAudioProcessorEditor (LPHPFilterAudioP
 {
     // Make sure that before the constructor has finished, you've set the
     // editor's size to whatever you need it to be.
-    constexpr auto HEIGHT = 400;
+    constexpr auto HEIGHT = 260;
     constexpr auto WIDTH = 200;
 
     addAndMakeVisible (cutoffFrequencySlider);

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -10,6 +10,34 @@
 #include "PluginEditor.h"
 
 //==============================================================================
+void RotarySliderLookAndFeel::drawRotarySlider (juce::Graphics& g, int x, int y, int width, int height,
+                                                float sliderPosProportional, float rotaryStartAngle,
+                                                float rotaryEndAngle, juce::Slider& slider)
+{
+    auto radius = juce::jmin (width / 2, height / 2) - 4.0f;
+    auto centreX = x + width * 0.5f;
+    auto centreY = y + height * 0.5f;
+    auto rx = centreX - radius;
+    auto ry = centreY - radius;
+    auto rw = radius * 2.0f;
+    auto angle = rotaryStartAngle + sliderPosProportional * (rotaryEndAngle - rotaryStartAngle);
+
+    g.setColour (juce::Colours::darkgrey);
+    g.fillEllipse (rx, ry, rw, rw);
+
+    g.setColour (juce::Colours::black);
+    g.drawEllipse (rx, ry, rw, rw, 1.0f);
+
+    juce::Path p;
+    auto pointerLength = radius * 0.6f;
+    auto pointerThickness = 2.0f;
+    p.addRectangle (-pointerThickness * 0.5f, -radius, pointerThickness, pointerLength);
+
+    g.setColour (juce::Colours::orange);
+    g.fillPath (p, juce::AffineTransform::rotation (angle).translated (centreX, centreY));
+}
+
+//==============================================================================
 LPHPFilterAudioProcessorEditor::LPHPFilterAudioProcessorEditor (LPHPFilterAudioProcessor& p, juce::AudioProcessorValueTreeState& vts)
     : AudioProcessorEditor (&p), audioProcessor (p)
 {
@@ -18,22 +46,20 @@ LPHPFilterAudioProcessorEditor::LPHPFilterAudioProcessorEditor (LPHPFilterAudioP
     constexpr auto HEIGHT = 400;
     constexpr auto WIDTH = 200;
 
-    addAndMakeVisible(cutoffFrequencySlider);
-    cutoffFrequencySlider.setSliderStyle(juce::Slider::SliderStyle::LinearVertical);
-    cutoffFrequencyAttachment.reset(
-        new juce::AudioProcessorValueTreeState::SliderAttachment(
-            vts, "cutoff_frequency", cutoffFrequencySlider));
+    addAndMakeVisible (cutoffFrequencySlider);
+    cutoffFrequencySlider.setSliderStyle (juce::Slider::RotaryHorizontalVerticalDrag);
+    cutoffFrequencySlider.setTextBoxStyle (juce::Slider::TextBoxBelow, false, 80, 20);
+    cutoffFrequencySlider.setLookAndFeel (&rotaryLook);
+    cutoffFrequencyAttachment.reset (new juce::AudioProcessorValueTreeState::SliderAttachment (vts, "cutoff_frequency", cutoffFrequencySlider));
 
-    addAndMakeVisible(cutoffFrequencyLabel);
-    cutoffFrequencyLabel.setText("Cutoff Frequency", juce::dontSendNotification);
+    addAndMakeVisible (cutoffFrequencyLabel);
+    cutoffFrequencyLabel.setText ("Cutoff Frequency", juce::dontSendNotification);
 
-    addAndMakeVisible(highpassButton);
-    highpassAttachment.reset(
-        new juce::AudioProcessorValueTreeState::ButtonAttachment(
-            vts, "highpass", highpassButton));
+    addAndMakeVisible (highpassButton);
+    highpassAttachment.reset (new juce::AudioProcessorValueTreeState::ButtonAttachment (vts, "highpass", highpassButton));
 
-    addAndMakeVisible(highpassButtonLabel);
-    highpassButtonLabel.setText("Highpass", juce::dontSendNotification);
+    addAndMakeVisible (highpassButtonLabel);
+    highpassButtonLabel.setText ("Highpass", juce::dontSendNotification);
 
     // Make sure that before the constructor has finished, you've set the
     // editor's size to whatever you need it to be.
@@ -42,29 +68,22 @@ LPHPFilterAudioProcessorEditor::LPHPFilterAudioProcessorEditor (LPHPFilterAudioP
 
 LPHPFilterAudioProcessorEditor::~LPHPFilterAudioProcessorEditor()
 {
+    cutoffFrequencySlider.setLookAndFeel (nullptr);
 }
 
 //==============================================================================
 void LPHPFilterAudioProcessorEditor::paint (juce::Graphics& g)
 {
-    // (Our component is opaque, so we must completely fill the background with a solid colour)
-    //g.fillAll(getLookAndFeel().findColour(juce::ResizableWindow::backgroundColourId));
+    g.fillAll (juce::Colours::black);
 
-    g.setColour(juce::Colours::whitesmoke);
-    g.setFont(15.0f);
-    //g.drawFittedText ("Hello World!", getLocalBounds(), juce::Justification::centred, 1);
-    cutoffFrequencySlider.setBounds({ 15, 35, 100, 300 });
-    cutoffFrequencyLabel.setBounds({ cutoffFrequencySlider.getX() + 30, cutoffFrequencySlider.getY() - 30,
-        200, 50 });
-    highpassButton.setBounds({ cutoffFrequencySlider.getX(),
-        cutoffFrequencySlider.getY() + cutoffFrequencySlider.getHeight() + 15, 30, 50 });
-    highpassButtonLabel.setBounds({ cutoffFrequencySlider.getX() + highpassButton.getWidth() + 15, highpassButton.getY(),
-        cutoffFrequencySlider.getWidth() - highpassButton.getWidth(),
-        highpassButton.getHeight() });
+    g.setColour (juce::Colours::whitesmoke);
+    g.setFont (15.0f);
 }
 
 void LPHPFilterAudioProcessorEditor::resized()
 {
-    // This is generally where you'll want to lay out the positions of any
-    // subcomponents in your editor..
+    cutoffFrequencySlider.setBounds ({ 25, 40, 150, 150 });
+    cutoffFrequencyLabel.setBounds ({ cutoffFrequencySlider.getX(), cutoffFrequencySlider.getY() - 20, 150, 20 });
+    highpassButton.setBounds ({ cutoffFrequencySlider.getX(), cutoffFrequencySlider.getBottom() + 15, 30, 30 });
+    highpassButtonLabel.setBounds ({ highpassButton.getRight() + 10, highpassButton.getY(), cutoffFrequencySlider.getWidth() - highpassButton.getWidth(), highpassButton.getHeight() });
 }

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -11,6 +11,14 @@
 #include <JuceHeader.h>
 #include "PluginProcessor.h"
 
+class RotarySliderLookAndFeel : public juce::LookAndFeel_V4
+{
+public:
+    void drawRotarySlider (juce::Graphics& g, int x, int y, int width, int height,
+                           float sliderPosProportional, float rotaryStartAngle,
+                           float rotaryEndAngle, juce::Slider& slider) override;
+};
+
 //==============================================================================
 /**
 */
@@ -29,6 +37,7 @@ private:
     // access the processor object that created it.
     LPHPFilterAudioProcessor& audioProcessor;
 
+    RotarySliderLookAndFeel rotaryLook;
     juce::Slider cutoffFrequencySlider;
     std::unique_ptr<juce::AudioProcessorValueTreeState::SliderAttachment>
         cutoffFrequencyAttachment;


### PR DESCRIPTION
## Summary
- implement custom LookAndFeel for a rotary slider
- use the custom look and feel on the cutoff frequency control and adjust layout
- add CMake build configuration using JUCE FetchContent

## Testing
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y cmake g++ pkg-config libx11-dev libxcomposite-dev libxcursor-dev libxinerama-dev libxrandr-dev libfreetype6-dev libasound2-dev libcurl4-openssl-dev` *(fails: unable to locate package)*
- `cmake -B build` *(fails: CONNECT tunnel failed, response 403 when cloning JUCE)*

------
https://chatgpt.com/codex/tasks/task_e_6897528480488331924884f6a4503cd1